### PR TITLE
bump up jspath

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "kd-polyfills": "^0.1.5",
     "kd-shim-canvas-loader": "^0.9.1",
     "kd-shim-inflector": "^0.1.0",
-    "kd-shim-jspath": "^0.1.0",
+    "kd-shim-jspath": "^0.2.0",
     "kd-shim-mutation-summary": "^0.1.0",
     "lodash.throttle": "^2.4.1",
     "mousetrap": "^1.4.6",


### PR DESCRIPTION
updated jspath to export js file https://github.com/kdmodules/jspath/tree/v0.2.0

this is the only coffee dependency left