### PR TITLE
1.2.0

### DIFF
--- a/lib/components/autocomplete/autocompletecontroller.coffee
+++ b/lib/components/autocomplete/autocompletecontroller.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:autocomplete:controller'
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDAutoCompleteListItemView = require './autocompletelistitem'
@@ -363,7 +364,7 @@ module.exports = class KDAutoCompleteController extends KDViewController
         @refreshDropDown data
         @showDropdown()
       else
-        KD.log 'no data found'
+        debug 'data not found'
         @showNoDataFound()
 
   keyUpOnInputView:(event)->

--- a/lib/components/buttons/buttonview.coffee
+++ b/lib/components/buttons/buttonview.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:buttons:buttonview'
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDView       = require '../../core/view'
@@ -120,7 +121,7 @@ module.exports = class KDButtonView extends KDView
         el.classList.add klass
 
     unless el?
-      KD.warn "No lazy DOM Element found with given id #{lazyDomId}."  if lazyDomId
+      debug "missing lazy dom element #{lazyDomId}"  if lazyDomId
       el =
       """
       <button type='#{@getOptions().type}' class='kdbutton #{cssClass}' id='#{@getId()}'>
@@ -196,7 +197,7 @@ module.exports = class KDButtonView extends KDView
   showLoader:->
 
     unless @loader
-      return KD.warn 'KDButtonView::showLoader is called where no loader is set'
+      debug 'missing loader'
 
     {icon, iconOnly} = @getOptions()
     @setClass "loading"
@@ -209,7 +210,7 @@ module.exports = class KDButtonView extends KDView
   hideLoader:->
 
     unless @loader
-      return KD.warn 'KDButtonView::hideLoader is called where no loader is set'
+      debug 'missing loader'
 
     {icon, iconOnly} = @getOptions()
     @unsetClass "loading"

--- a/lib/components/buttons/togglebutton.coffee
+++ b/lib/components/buttons/togglebutton.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:buttons:togglebutton'
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDButtonView = require './buttonview'
@@ -56,7 +57,6 @@ module.exports = class KDToggleButton extends KDButtonView
       @setState nextState.title
     else
       unless err.name is 'AccessDenied'
-        KD.warn err.message or \
-          "There was an error, couldn't switch to #{nextState.title} state!"
+        debug err.message or "could not switch to state #{nextState.title}"
 
     @hideLoader?()

--- a/lib/components/dia/diajoint.coffee
+++ b/lib/components/dia/diajoint.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:dia:diajoint'
 KD = require '../../core/kd'
 KDView = require '../../core/view'
 
@@ -9,7 +10,7 @@ module.exports = class KDDiaJoint extends KDView
 
     options.type   or= 'left'
     unless options.type in types
-      KD.warn "Unknown joint type '#{options.type}', falling back to 'left'"
+      debug "unknown joint type '#{options.type}', falling back to 'left'"
       options.type = 'left'
 
     options.static  ?= no

--- a/lib/components/dia/diaobject.coffee
+++ b/lib/components/dia/diaobject.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:dia:diaobject'
 KD = require '../../core/kd'
 KDDiaJoint = require './diajoint'
 KDView = require '../../core/view'
@@ -65,7 +66,7 @@ module.exports = class KDDiaObject extends KDView
   addJoint:(type)->
 
     if @joints[type]?
-      KD.warn "KDDiaObject: Tried to add same joint! Destroying old one. "
+      debug 'dup joint, overriding previous one'
       @joints[type].destroy?()
 
     {jointItemClass, staticJoints} = @getOptions()

--- a/lib/components/dia/diascene.coffee
+++ b/lib/components/dia/diascene.coffee
@@ -1,8 +1,8 @@
-$ = require 'jquery'
-KD = require '../../core/kd'
+$                = require 'jquery'
+KD               = require '../../core/kd'
 KDView           = require '../../core/view'
 KDCustomHTMLView = require '../../core/customhtmlview'
-_throttle        = require 'lodash.throttle'
+_                = require 'lodash'
 
 module.exports = class KDDiaScene extends KDView
 
@@ -194,11 +194,12 @@ module.exports = class KDDiaScene extends KDView
     @fakeConnections = []
     @updateScene()
 
-  updateScene:->
+  updateScene: _.throttle ->
 
     @cleanup @realCanvas
     @drawConnectionLine connection for connection in @connections
     @drawConnectionLine connection for connection in @fakeConnections
+  , 300
 
   drawConnectionLine:({source, target, options})->
 
@@ -279,7 +280,7 @@ module.exports = class KDDiaScene extends KDView
 
   parentDidResize:->
     super
-    do _throttle => @updateScene()
+    @updateScene()
 
   getSceneSize:-> width: @getWidth(), height: @getHeight()
 

--- a/lib/components/dia/diascene.coffee
+++ b/lib/components/dia/diascene.coffee
@@ -284,7 +284,7 @@ module.exports = class KDDiaScene extends KDView
   getSceneSize:-> width: @getWidth(), height: @getHeight()
 
   dumpScene:->
-    KD.log @containers, @connections
+    console.log @containers, @connections
 
   reset:(update = yes)->
     @connections     = []

--- a/lib/components/inputs/inputvalidator.coffee
+++ b/lib/components/inputs/inputvalidator.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:inputs:inputvalidator'
 $ = require 'jquery'
 KD = require '../../core/kd'
 module.exports = class KDInputValidator
@@ -127,7 +128,7 @@ module.exports = class KDInputValidator
     try
       JSON.parse value if value
     catch err
-      KD.error err,doesValidate
+      debug 'could not parse json', err, doesValidate
       doesValidate = no
 
     if doesValidate

--- a/lib/components/inputs/inputview.coffee
+++ b/lib/components/inputs/inputview.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:inputs:inputview'
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDNotificationView = require '../notifications/notificationview'
@@ -187,7 +188,7 @@ module.exports = class KDInputView extends KDView
       for option in options
         @$().append "<option value='#{option.value}'>#{option.title}</option>"
     else
-      KD.warn "no valid options specified for the input:", @
+      debug "got invalid arguments"
 
     @$().val @getDefaultValue()
 

--- a/lib/components/inputs/selectbox.coffee
+++ b/lib/components/inputs/selectbox.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:inputs:selectbox'
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDInputView = require './inputview'
@@ -67,7 +68,7 @@ module.exports = class KDSelectBox extends KDInputView
         @_$select.append "<option value='#{option.value}'>#{option.title}</option>"
         firstOption or= option
     else
-      KD.warn "no valid options specified for the input:", @
+      debug "got invalid arguments"
 
     value = @getDefaultValue() or firstOption?.value or ""
     @_$select.val value + "" # casting to number in case, i don't remember why though. SY

--- a/lib/components/list/listitemview.coffee
+++ b/lib/components/list/listitemview.coffee
@@ -50,6 +50,8 @@ module.exports = class KDListItemView extends KDView
   getItemDataId: ->
     data = @getData()
 
+    return  unless data
+
     id = if data.getId?() then data.getId()
     else if data.id?      then data.id
     else if data._id?     then data._id

--- a/lib/components/list/listview.coffee
+++ b/lib/components/list/listview.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:list:listview'
 KD = require '../../core/kd'
 KDListItemView = require './listitemview'
 KDView        = require '../../core/view'
@@ -205,7 +206,7 @@ module.exports = class KDListView extends KDView
 
     currentIndex = @getItemIndex item
     if currentIndex < 0
-      KD.warn "Item doesn't exists", item
+      debug "missing item", item
       return @items
 
     newIndex = Math.max(0, Math.min(@items.length-1, newIndex))

--- a/lib/components/list/listviewcontroller.coffee
+++ b/lib/components/list/listviewcontroller.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:list:listviewcontroller'
 KD = require '../../core/kd'
 KDView             = require '../../core/view'
 KDViewController   = require '../../core/viewcontroller'
@@ -26,7 +27,7 @@ module.exports = class KDListViewController extends KDViewController
     options.lastToFirst            ?= no
 
     Object.defineProperty this, "itemsOrdered", get : =>
-      KD.warn "KDListViewController::itemsOrdered is deprecated."
+      debug 'itemsOrdered is deprecated'
       @getListItems()
 
     @itemsIndexed                 = {}

--- a/lib/components/modals/modalviewstack.coffee
+++ b/lib/components/modals/modalviewstack.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:modals:modalviewstack'
 KD = require '../../core/kd'
 KDModalView = require './modalview'
 KDObject = require '../../core/object'
@@ -13,7 +14,8 @@ module.exports = class KDModalViewStack extends KDObject
   addModal: (modal)->
 
     unless modal instanceof KDModalView
-      return KD.warn "You can only add KDModalView instances to the modal stack."
+      debug 'modal must be an instanceof kd.ModalView'
+      return
 
     modal.on "KDObjectWillBeDestroyed", => @next()
 

--- a/lib/components/modals/modalviewwithforms.coffee
+++ b/lib/components/modals/modalviewwithforms.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:modals:modalviewwithforms'
 KDModalView        = require './modalview'
 KDTabViewWithForms = require '../tabs/tabviewwithforms'
 
@@ -20,7 +21,7 @@ module.exports = class KDModalViewWithForms extends KDModalView
 
     data.reduce (acc, form) ->
       for own key, val of form.data
-        console.warn "Property #{key} will be overwitten!"  if key of acc
+        debug "overriding #{key}"  if key of acc
         acc[key] = val
       return acc
     , {}

--- a/lib/components/split/splitpanel.coffee
+++ b/lib/components/split/splitpanel.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:split:splitpanel'
 KD = require '../../core/kd'
 KDSplitView = require './splitview'
 KDScrollView = require '../scrollview/scrollview'
@@ -19,7 +20,8 @@ module.exports = class KDSplitViewPanel extends KDScrollView
 
   splitPanel: (options = {}) ->
     if @subViews.first instanceof KDSplitView
-      return KD.warn "this panel is already splitted"
+      debug 'panel is already split'
+      return
 
     view      = @subViews.first
     index     = @parent.panels.indexOf this

--- a/lib/components/split/splitview.coffee
+++ b/lib/components/split/splitview.coffee
@@ -1,3 +1,4 @@
+debug            = require('debug') 'kd:split:splitview'
 KD               = require '../../core/kd'
 KDView           = require '../../core/view'
 KDSplitViewPanel = require './splitpanel'
@@ -355,9 +356,9 @@ module.exports = class KDSplitView extends KDView
 
   setView: (view, index) ->
 
-    return KD.warn "view is missing at KDSplitView::setView"   unless view
-    return KD.warn "index is missing at KDSplitView::setView"  if index > @panels.length
-    return KD.warn "index is missing at KDSplitView::setView"  unless view instanceof KDView
+    return debug "missing view"       unless view
+    return debug "missing index"      if index > @panels.length
+    return debug "invalid view type"  unless view instanceof KDView
 
     @panels[index].addSubView view
 

--- a/lib/components/split/splitview.coffee
+++ b/lib/components/split/splitview.coffee
@@ -361,10 +361,3 @@ module.exports = class KDSplitView extends KDView
     return debug "invalid view type"  unless view instanceof KDView
 
     @panels[index].addSubView view
-
-
-  # deprecated methods
-  deprecated = -> KD.warn 'deprecated method invoked'
-  _repositionPanels: deprecated
-  _repositionResizers: deprecated
-  _setPanelPositions: deprecated

--- a/lib/components/tabs/tabpaneview.coffee
+++ b/lib/components/tabs/tabpaneview.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:tabs:tabpaneview'
 KD = require '../../core/kd'
 KDView = require '../../core/view'
 
@@ -92,7 +93,7 @@ module.exports = class KDTabPaneView extends KDView
       {viewClass, options, data} = viewOptions
       @mainView = @addSubView new viewClass options, data
     else
-      return KD.warn "probably you set a weird lazy view!"
+      return debug 'invalid view type'
 
     @emit "KDTabPaneLazyViewAdded", this, @mainView
     return @mainView

--- a/lib/components/tabs/tabview.coffee
+++ b/lib/components/tabs/tabview.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:tabs:tabpaneview'
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDTabHandleView = require './tabhandleview'
@@ -69,7 +70,7 @@ module.exports = class KDTabView extends KDScrollView
 
     unless paneInstance instanceof KDTabPaneView
       {name} = paneInstance?.constructor?
-      KD.warn "You can't add #{name if name} as a pane, use KDTabPaneView instead"
+      debug "can't add #{name if name} as a pane, use kd.TabPaneView instead"
       return no
 
 
@@ -198,7 +199,7 @@ module.exports = class KDTabView extends KDScrollView
 
     unless handle instanceof KDTabHandleView
       {name} = handle?.constructor?
-      KD.warn "You can't add #{name if name?} as a pane, use KDTabHandleView instead"
+      debug "can't add #{name if name?} as a pane, use kd.TabHandleView instead"
       return no
 
     @handles.push handle

--- a/lib/components/tree/treeviewcontroller.coffee
+++ b/lib/components/tree/treeviewcontroller.coffee
@@ -84,7 +84,7 @@ module.exports = class JTreeViewController extends KDViewController
 
     o = @getOptions()
     for own index, node of @indexedNodes
-      KD.log index, @getNodeId(node), @getNodePId(node), node.depth
+      console.log index, @getNodeId(node), @getNodePId(node), node.depth
 
   getNodeId:(nodeData)->
 

--- a/lib/core/kd.coffee
+++ b/lib/core/kd.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd'
 utils = require './utils'
 dom = require 'kd-dom'
 
@@ -12,7 +13,7 @@ getSingleton = (name) ->
   if singletons[name]?
     singletons[name]
   else
-    console.warn "[getSingleton] #{name} doesn't exist"
+    debug "could not found singleton #{name}"
     null
 
 module.exports =
@@ -24,19 +25,18 @@ module.exports =
   registerSingleton: (name, obj, override = no)->
     if (existing = singletons[name])?
       if override
-        console.warn "[registerSingleton] overriding #{name}"
+        debug "overriding singleton #{name}"
         existing.destroy?()
         singletons[name] = obj
       else
-        console.error "[registerSingleton] #{name} exists. if you want to override set override param to true."
+        debug "cowardly refusing to override singleton #{name} without being explicitly told to do so"
         singletons[name]
-      # KDObject.emit "singleton.#{name}.registered"
     else
-      # log "singleton registered! KD.singletons[\"#{name}\"]"
+      debug "registered singleton #{name}"
       singletons[name] = obj
 
   registerInstance: (inst) ->
-    console.warn '[registerInstance] instance is being overwritten' if instances[inst.id]
+    debug "overriding instance #{inst.id}"  if instances[inst.id]
     instances[inst.id] = inst
 
   unregisterInstance: (id) ->

--- a/lib/core/object.coffee
+++ b/lib/core/object.coffee
@@ -20,7 +20,7 @@ module.exports = class KDObject extends KDEventEmitter
     if options.testPath
       KD.registerInstanceForTesting this
 
-    @on 'error', KD.error
+    @on   'error', console.error.bind console
     @once 'ready', => @readyState = READY
 
 

--- a/lib/core/router.coffee
+++ b/lib/core/router.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:router'
 KD = require './kd'
 KDObject           = require './object'
 KDNotificationView = require '../components/notifications/notificationview'
@@ -70,8 +71,7 @@ module.exports = class KDRouter extends KDObject
     return yes
 
   @handleNotFound =(route)->
-    console.trace()
-    KD.log "The route #{ Encoder.XSSEncode route } was not found!"
+    debug "route #{route} not found"
 
   getCurrentPath:-> @currentPath
 
@@ -83,7 +83,7 @@ module.exports = class KDRouter extends KDObject
 
     delete @userRoute
     @clear()
-    KD.log "The route #{route} was not found!"
+    debug "route #{route} not found"
     new KDNotificationView title: message
 
   routeWithoutEdgeAtIndex =(route, i)->

--- a/lib/core/utils.coffee
+++ b/lib/core/utils.coffee
@@ -355,7 +355,7 @@ module.exports =
     kallback
 
   logTimer:(timerName, timerNumber, startTime)->
-    log "logTimer name:#{timerName}"
+    console.log "logTimer name:#{timerName}"
 
     @timers[timerName] ||= {}
     @timers[timerName][timerNumber] =
@@ -375,7 +375,7 @@ module.exports =
 
     @timers[timerName][timerNumber] = timer
 
-    log "updateLogTimer name:#{timerName}, status:#{status} elapsed:#{elapsed}"
+    console.log "updateLogTimer name:#{timerName}, status:#{status} elapsed:#{elapsed}"
 
   timers: {}
 

--- a/lib/core/utils.coffee
+++ b/lib/core/utils.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:utils'
 Inflector = require 'inflector'
 
 module.exports =
@@ -444,7 +445,7 @@ module.exports =
       callback data?.id or url, data
 
     request.error ({status, statusText, responseText})->
-      error "URL shorten error, returning self as fallback.", status, statusText, responseText
+      debug "could not shorten url #{url}", status, statusText, responseText
       callback url
 
   formatBytesToHumanReadable: (bytes, fixedAmout = 2) ->

--- a/lib/core/view.coffee
+++ b/lib/core/view.coffee
@@ -11,8 +11,6 @@ module.exports = class KDView extends KDObject
 
   {defineProperty} = Object
 
-  deprecated = (methodName)-> KD.warn "#{methodName} is deprecated from KDView if you need it override in your subclass"
-
   eventNames =
     ///
     ^(

--- a/lib/core/view.coffee
+++ b/lib/core/view.coffee
@@ -65,10 +65,6 @@ module.exports = class KDView extends KDObject
       $("body").append @$()
       @utils.defer => @emit "viewAppended"
 
-  @appendToDOMBody = (view) ->
-    KD.warn "KDView.appendToDOMBody is deprecated; use #appendToDomBody instead"
-    view.appendToDomBody()
-
 # #
 # INSTANCE LEVEL
 # #
@@ -915,7 +911,7 @@ module.exports = class KDView extends KDObject
     windowController = KD.getSingleton 'windowController'
     windowController.setKeyView this
 
-  unsetKeyView: -> 
+  unsetKeyView: ->
     windowController = KD.getSingleton 'windowController'
     windowController.setKeyView null
 

--- a/lib/core/view.coffee
+++ b/lib/core/view.coffee
@@ -1,3 +1,4 @@
+debug = require('debug') 'kd:view'
 $ = require 'jquery'
 KD = require './kd'
 KDObject        = require './object'
@@ -170,7 +171,7 @@ module.exports = class KDView extends KDObject
     @domElement = $ el
 
     if @lazy
-      # warn "lazyElement found with id #{domId}"
+      debug "lazyElement found with id #{domId}"
       @utils.defer => @emit 'viewAppended'
 
   setDomId:(id)->
@@ -427,7 +428,6 @@ module.exports = class KDView extends KDObject
       if shouldPrepend
       then @prepend subView, selector
       else @append subView, selector
-    # else log "lazy view", subView
 
     subView.on "ViewResized", -> subView.parentDidResize()
 

--- a/lib/core/view.coffee
+++ b/lib/core/view.coffee
@@ -451,7 +451,7 @@ module.exports = class KDView extends KDObject
     subViews
 
   setParent:(parent)->
-    if @parent? then KD.error 'View already has a parent', this, @parent
+    if @parent? then debug 'view already has a parent', this, @parent
     else
       if defineProperty
         defineProperty @, 'parent', value : parent, configurable : yes

--- a/lib/core/windowcontroller.coffee
+++ b/lib/core/windowcontroller.coffee
@@ -1,6 +1,7 @@
-$                  = require 'jquery'
-KD                 = require './kd'
-KDController       = require './controller'
+debug        = require('debug') 'kd:windowcontroller'
+$            = require 'jquery'
+KD           = require './kd'
+KDController = require './controller'
 
 ###
 todo:
@@ -175,7 +176,7 @@ module.exports = class KDWindowController extends KDController
   revertKeyView:(view)->
 
     unless view
-      KD.warn 'view, which shouldn\'t be the keyview anymore, must be passed as a parameter!'
+      debug 'missing view'
       return
 
     if view is @keyView and @keyView isnt @oldKeyView

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -4,6 +4,8 @@ module.exports = require './core/kd'
 
 module.exports.extend
 
+  debug                          : require 'debug'
+
   AutoComplete                   : require "./components/autocomplete/autocomplete"
   AutoCompleteController         : require "./components/autocomplete/autocompletecontroller"
   AutoCompletedItem              : require "./components/autocomplete/autocompleteditems"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "debug": "^2.1.3",
     "hammerjs": "^2.0.4",
     "htmlencode": "0.0.4",
     "jquery": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "kd-shim-inflector": "^0.1.0",
     "kd-shim-jspath": "^0.2.0",
     "kd-shim-mutation-summary": "^0.1.0",
+    "lodash": "^3.6.0",
     "timeago": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "kd-shim-inflector": "^0.1.0",
     "kd-shim-jspath": "^0.2.0",
     "kd-shim-mutation-summary": "^0.1.0",
-    "lodash.throttle": "^2.4.1",
     "timeago": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* migrates all the way to [debug](https://github.com/visionmedia/debug) for logging
* exposes `debug` so it is possible to do `kd.debug.enable('kd:*')` in browser
* removes obsolete `appendToDOMBody`
* removes obsolete `SplitView` methods
* removes obsolete `deprecated` method in `view`
* log messages are redacted
* npm: removes lodash.throttle@2.4.1, adds lodash@3.6.0
* makes `dia/diascene` throttle indeed